### PR TITLE
Launchers for scala/dotty given a PR, git ref, or maven version

### DIFF
--- a/scafu.sh
+++ b/scafu.sh
@@ -68,7 +68,7 @@ alias scala="~/scala/latest/bin/scala"
 alias scalac="~/scala/latest/bin/scalac"
 alias scala29="~/scala/2.9/bin/scala"
 alias scalac29="~/scala/2.9/bin/scalac"
-=======
+
 
 function nodebug () {
   export JAVA_OPTS=""

--- a/scafu.sh
+++ b/scafu.sh
@@ -1,5 +1,9 @@
 function jardiff() {
-    java -jar /Users/adriaan/git/jardiff/core/target/scala-2.12/jardiff-core-assembly-1.0-SNAPSHOT.jar "$@";
+    [[ -f "$JARDIFF_JAR" ]] || (
+        echo "Please download https://gitreleases.dev/gh/scala/jardiff/latest/jardiff.jar to a location specified by \$JARDIFF_JAR" >&2
+        return 1
+    )
+    java -jar "$JARDIFF_JAR" "$@";
 }
 
 function nodebug () {


### PR DESCRIPTION
Requirements:

  - Add a GitHub access token to your git config
(https://github.blog/2008-10-11-local-github-config/)
 - `brew install coursier`

Demo:

```
$ scala-ref-version 4b5835c839~23 2.12.9-bin-f07f779-SNAPSHOT

$ scala-pr-version 8128 2.12.9-bin-05e2ca1-SNAPSHOT

$ scalac-pr 8128 -version Scala compiler version
2.12.9-20190606-165420-05e2ca1 -- Copyright 2002-2019, LAMP/EPFL and
Lightbend, Inc.

$ scala-pr 8128 -version Scala code runner version
2.12.9-20190606-165420-05e2ca1 -- Copyright 2002-2019, LAMP/EPFL and
Lightbend, Inc.

$ scala-launch 2.12.8 -version Scala code runner version 2.12.8 --
Copyright 2002-2018, LAMP/EPFL and Lightbend, Inc.
```